### PR TITLE
Make the `bindService` method `final`

### DIFF
--- a/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/ImplBaseGenerator.kt
+++ b/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/ImplBaseGenerator.kt
@@ -134,7 +134,7 @@ object ImplBaseGenerator {
 
         builder.addFunction(
             FunSpec.builder("bindService")
-                .addModifiers(KModifier.OVERRIDE)
+                .addModifiers(KModifier.OVERRIDE, KModifier.FINAL)
                 .returns(ClassName("io.grpc", "ServerServiceDefinition"))
                 .addCode(bindServiceCodeBlock(service, options))
                 .build(),

--- a/server-generator/src/test/golden/ImplBase.kt
+++ b/server-generator/src/test/golden/ImplBase.kt
@@ -28,7 +28,7 @@ public class RouteGuideWireGrpc {
     public open fun RouteChat(response: StreamObserver<RouteNote>): StreamObserver<RouteNote> =
         throw UnsupportedOperationException()
 
-    override fun bindService(): ServerServiceDefinition =
+    final override fun bindService(): ServerServiceDefinition =
         ServerServiceDefinition.builder(getServiceDescriptor()).addMethod(
               getGetFeatureMethod(),
               asyncUnaryCall(this@RouteGuideImplBase::GetFeature)

--- a/server-generator/src/test/golden/RouteGuideWireGrpc.kt
+++ b/server-generator/src/test/golden/RouteGuideWireGrpc.kt
@@ -224,7 +224,7 @@ public object RouteGuideWireGrpc {
     public open fun RouteChat(response: StreamObserver<RouteNote>): StreamObserver<RouteNote> =
         throw UnsupportedOperationException()
 
-    override fun bindService(): ServerServiceDefinition =
+    final override fun bindService(): ServerServiceDefinition =
         ServerServiceDefinition.builder(getServiceDescriptor()).addMethod(
               getGetFeatureMethod(),
               serverCallsAsyncUnaryCall(this@RouteGuideImplBase::GetFeature)

--- a/server-generator/src/test/golden/nonSingleMethodService.kt
+++ b/server-generator/src/test/golden/nonSingleMethodService.kt
@@ -145,7 +145,7 @@ public object FooServiceWireGrpc {
     public open fun Call2(request: Request, response: StreamObserver<Response>): Unit = throw
         UnsupportedOperationException()
 
-    override fun bindService(): ServerServiceDefinition =
+    final override fun bindService(): ServerServiceDefinition =
         ServerServiceDefinition.builder(getServiceDescriptor()).addMethod(
               getCall1Method(),
               serverCallsAsyncUnaryCall(this@FooServiceImplBase::Call1)

--- a/server-generator/src/test/golden/singleMethodService.kt
+++ b/server-generator/src/test/golden/singleMethodService.kt
@@ -145,7 +145,7 @@ public object FooServiceWireGrpc {
     public open fun Call2(request: Request, response: StreamObserver<Response>): Unit = throw
         UnsupportedOperationException()
 
-    override fun bindService(): ServerServiceDefinition =
+    final override fun bindService(): ServerServiceDefinition =
         ServerServiceDefinition.builder(getServiceDescriptor()).addMethod(
               getCall1Method(),
               serverCallsAsyncUnaryCall(this@FooServiceImplBase::Call1)

--- a/server-generator/src/test/golden/unitService.kt
+++ b/server-generator/src/test/golden/unitService.kt
@@ -115,7 +115,7 @@ public object MyServiceWireGrpc {
   ) : WireBindableService {
     public open suspend fun doSomething(request: Unit): Unit = throw UnsupportedOperationException()
 
-    override fun bindService(): ServerServiceDefinition =
+    final override fun bindService(): ServerServiceDefinition =
         ServerServiceDefinition.builder(getServiceDescriptor()).addMethod(
                io.grpc.kotlin.ServerCalls.unaryServerMethodDefinition(
                  context = context,


### PR DESCRIPTION
Thanks for your amazing work on Wire.

I noticed an inconsistency between gRPC-java and Wire's output that, if resolved, enables Wire to be integrated with tools that expect gRPC-java's output.

Since 2016, grpc-java's [generated `bindService` method](https://github.com/grpc/grpc-java/blob/6f3542297c2fb46a38cab65d510fc2ce76200045/compiler/src/java_plugin/cpp/java_generator.cpp#L836) has been `final`. See the grpc-java [issue](https://github.com/grpc/grpc-java/issues/2552) for related discussion.

Making wire's generated code consistent with this makes it compatible with related tooling that depends on this, such as [gRPC-Spring](https://github.com/grpc-ecosystem/grpc-spring)'s [support](https://github.com/grpc-ecosystem/grpc-spring/blob/a18aeeb25e60114ea773a621bfdc44902513ed07/tests/src/test/java/net/devh/boot/grpc/test/config/AnnotatedSecurityConfiguration.java#L27) for Spring's method security.