### PR TITLE
Bump Wire to 5.4.0

### DIFF
--- a/build-support/build.gradle.kts
+++ b/build-support/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
@@ -23,7 +24,7 @@ buildscript {
 plugins {
   `kotlin-dsl`
   `java-gradle-plugin`
-  kotlin("jvm") version "1.9.10"
+  kotlin("jvm") version libs.versions.kotlin
 }
 
 repositories {
@@ -77,13 +78,12 @@ allprojects {
   }
 
   tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions {
-      jvmTarget = "11"
-      // Disable optimized callable references. See https://youtrack.jetbrains.com/issue/KT-37435
-      freeCompilerArgs += "-Xno-optimized-callable-references"
-      freeCompilerArgs += "-Xjvm-default=all"
+    compilerOptions {
+      jvmTarget.set(JvmTarget.JVM_11)
+      freeCompilerArgs.add("-Xno-optimized-callable-references")
+      freeCompilerArgs.add("-Xjvm-default=all")
       // https://kotlinlang.org/docs/whatsnew13.html#progressive-mode
-      freeCompilerArgs += "-progressive"
+      freeCompilerArgs.add("-progressive")
     }
   }
 }

--- a/build-support/settings.gradle.kts
+++ b/build-support/settings.gradle.kts
@@ -1,5 +1,8 @@
 rootProject.name = "build-support"
 
+include(":server-generator")
+project(":server-generator").projectDir = File("../server-generator")
+
 dependencyResolutionManagement {
   versionCatalogs {
     create("libs").from(files("../gradle/libs.versions.toml"))

--- a/build-support/src/main/kotlin/com/squareup/wiregrpcserver/buildsupport/WireGrpcServerBuildPlugin.kt
+++ b/build-support/src/main/kotlin/com/squareup/wiregrpcserver/buildsupport/WireGrpcServerBuildPlugin.kt
@@ -38,10 +38,12 @@ import org.gradle.kotlin.dsl.attributes
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.dokka.gradle.DokkaTask
-import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 import java.io.File
+import kotlin.text.set
 
 private lateinit var wireGroupId: String
 private lateinit var wireVersion: String
@@ -187,9 +189,9 @@ class WireGrpcServerBuildPlugin : Plugin<Project> {
     }
 
     private fun Project.configureCommonKotlin() {
-        tasks.withType(KotlinCompile::class.java).configureEach {
-            kotlinOptions {
-                freeCompilerArgs += listOf(
+        tasks.withType(KotlinCompilationTask::class.java).configureEach {
+            compilerOptions {
+                freeCompilerArgs.addAll(
                     // Disable optimized callable references. See https://youtrack.jetbrains.com/issue/KT-37435
                     "-Xno-optimized-callable-references",
                     // https://kotlinlang.org/docs/whatsnew13.html#progressive-mode
@@ -200,9 +202,9 @@ class WireGrpcServerBuildPlugin : Plugin<Project> {
 
         val javaVersion = JavaVersion.VERSION_1_8
         tasks.withType(KotlinJvmCompile::class.java).configureEach {
-            kotlinOptions {
-                jvmTarget = javaVersion.toString()
-                freeCompilerArgs += listOf(
+            compilerOptions {
+                jvmTarget.set(JvmTarget.JVM_1_8)
+                freeCompilerArgs.addAll(
                     "-Xjvm-default=all",
                 )
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ buildscript {
 
     classpath(libs.wire.gradlePlugin)
     classpath(libs.wire.runtime)
+    classpath("com.squareup.wiregrpcserver:server-generator")
     classpath("com.squareup.wiregrpcserver.build:gradle-plugin")
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ jimfs = "1.3.0"
 jmh = "1.37"
 jsr305 = "3.0.2"
 junit = "4.13.2"
-kotlin = "1.9.10"
+kotlin = "2.2.21"
 kotlinpoet = "1.15.3"
 ktlint = "0.48.2"
 moshi = "1.15.0"
@@ -21,7 +21,7 @@ okhttp = "4.12.0"
 okio = "3.7.0"
 protobuf = "3.25.1"
 protobufGradlePlugin = "0.9.4"
-wire = "4.9.3"
+wire = "5.4.0"
 
 [libraries]
 android = { module = "com.google.android:android", version.ref = "android" }
@@ -41,6 +41,7 @@ grpc-genJava = { module = "io.grpc:protoc-gen-grpc-java", version.ref = "grpc" }
 grpc-netty = { module = "io.grpc:grpc-netty", version.ref = "grpc" }
 grpc-protobuf = { module = "io.grpc:grpc-protobuf", version.ref = "grpc" }
 grpc-stub = { module = "io.grpc:grpc-stub", version.ref = "grpc" }
+grpc-kotlin-stub = { module = "io.grpc:grpc-kotlin-stub", version = "1.5.0" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 javapoet = { module = "com.squareup:javapoet", version.ref = "javapoet" }
@@ -76,7 +77,7 @@ okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesystem", versio
 # Check https://docs.gradle.org/current/userguide/platforms.html#sec:version-catalog-plugin
 #  if we ever wanna migrate to this.
 pluginz-android = { module = "com.android.tools.build:gradle", version = "8.2.0" }
-pluginz-binaryCompatibilityValidator = { module = "org.jetbrains.kotlinx.binary-compatibility-validator:org.jetbrains.kotlinx.binary-compatibility-validator.gradle.plugin", version = "0.13.2" }
+pluginz-binaryCompatibilityValidator = { module = "org.jetbrains.kotlinx.binary-compatibility-validator:org.jetbrains.kotlinx.binary-compatibility-validator.gradle.plugin", version = "0.18.1" }
 pluginz-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 pluginz-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 pluginz-kotlinSerialization = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }

--- a/samples/wire-grpc-sample/server-plain/build.gradle.kts
+++ b/samples/wire-grpc-sample/server-plain/build.gradle.kts
@@ -1,3 +1,8 @@
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
   kotlin("jvm")
   id("com.squareup.wire")
@@ -12,19 +17,41 @@ wire {
   sourcePath {
     srcDir("$rootDir/samples/wire-grpc-sample/protos/src/main/proto")
   }
+  custom {
+    schemaHandlerFactory = com.squareup.wire.kotlin.grpcserver.GrpcServerSchemaHandler.Factory()
+    options = mapOf(
+      "singleMethodServices" to "true",
+      "rpcCallStyle" to "blocking",
+    )
+    exclusive = false
+  }
+
   kotlin {
     rpcCallStyle = "blocking"
     rpcRole = "server"
     singleMethodServices = true
-    grpcServerCompatible = true
   }
 }
 
 dependencies {
+  implementation(libs.grpc.kotlin.stub)
   implementation(projects.samples.wireGrpcSample.protos)
   implementation(projects.server)
-  implementation(libs.wire.runtime)
   implementation(libs.grpc.netty)
-  implementation(libs.grpc.stub)
   implementation(libs.grpc.protobuf)
+  implementation(libs.grpc.stub)
+  implementation(libs.kotlin.coroutines.core)
+  implementation(libs.wire.runtime)
+}
+
+tasks.withType<JavaCompile>().configureEach {
+  sourceCompatibility = JavaVersion.VERSION_17.toString()
+  targetCompatibility = JavaVersion.VERSION_17.toString()
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+  compilerOptions {
+    jvmTarget.set(JvmTarget.JVM_17)
+    freeCompilerArgs.add("-Xjvm-default=all")
+  }
 }

--- a/server-generator/build.gradle.kts
+++ b/server-generator/build.gradle.kts
@@ -12,7 +12,6 @@ dependencies {
   implementation(libs.okio.core)
   api(libs.kotlinpoet)
   api(libs.protobuf.java)
-  implementation(projects.server)
   testImplementation(libs.wire.schemaHandlerTests)
   testImplementation(libs.kotlin.test.junit)
   testImplementation(libs.okio.fakefilesystem)

--- a/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/BindableAdapterGenerator.kt
+++ b/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/BindableAdapterGenerator.kt
@@ -20,6 +20,7 @@ import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.LambdaTypeName
+import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
@@ -199,19 +200,19 @@ object BindableAdapterGenerator {
                     )
                     !rpc.requestStreaming -> CodeBlock.of(
                         "return %T.serverStream(context, request, %L()::%L)",
-                        FlowAdapter::class,
+                        ClassName("com.squareup.wire.kotlin.grpcserver","FlowAdapter"),
                         serviceProviderName,
                         rpc.name,
                     )
                     !rpc.responseStreaming -> CodeBlock.of(
                         "return %T.clientStream(context, request, %L()::%L)",
-                        FlowAdapter::class,
+                        ClassName("com.squareup.wire.kotlin.grpcserver","FlowAdapter"),
                         serviceProviderName,
                         rpc.name,
                     )
                     else -> CodeBlock.of(
                         "return %T.bidiStream(context, request, %L()::%L)",
-                        FlowAdapter::class,
+                        ClassName("com.squareup.wire.kotlin.grpcserver","FlowAdapter"),
                         serviceProviderName,
                         rpc.name,
                     )

--- a/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/GrpcServerSchemaHandler.kt
+++ b/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/GrpcServerSchemaHandler.kt
@@ -152,10 +152,6 @@ class GrpcServerSchemaHandler(
 
     @Suppress("unused") // Used by the library's consumers.
     class Factory : SchemaHandler.Factory {
-        override fun create(): SchemaHandler {
-            error("Not used. Wire will remove it soon.")
-        }
-
         override fun create(
             includes: List<String>,
             excludes: List<String>,

--- a/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/ImplBaseGenerator.kt
+++ b/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/ImplBaseGenerator.kt
@@ -44,7 +44,7 @@ object ImplBaseGenerator {
         .addType(
             TypeSpec.classBuilder("${service.name}ImplBase")
                 .addModifiers(KModifier.ABSTRACT)
-                .addSuperinterface(WireBindableService::class)
+                .addSuperinterface(ClassName("com.squareup.wire.kotlin.grpcserver","WireBindableService"))
                 .apply { addImplBaseConstructor(options) }
                 .apply { addImplBaseBody(generator, this, service, options) }
                 .build(),
@@ -147,7 +147,7 @@ object ImplBaseGenerator {
                 val className = generator.classNameFor(it!!)
                 builder.addType(
                     TypeSpec.classBuilder("${it.simpleName}Marshaller")
-                        .addSuperinterface(WireMethodMarshaller::class.asClassName().parameterizedBy(className))
+                        .addSuperinterface(ClassName("com.squareup.wire.kotlin.grpcserver","WireMethodMarshaller").parameterizedBy(className))
                         .addFunction(
                             FunSpec.builder("stream")
                                 .addModifiers(KModifier.OVERRIDE)

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -4,8 +4,6 @@ plugins {
   kotlin("jvm")
 }
 
-
-
 dependencies {
   implementation(libs.wire.runtime)
   // io.grpc.stub relies on guava-android. This module relies on a -jre version of guava.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,12 +24,12 @@ dependencyResolutionManagement {
 includeBuild("build-support") {
   dependencySubstitution {
     substitute(module("com.squareup.wiregrpcserver.build:gradle-plugin")).using(project(":"))
+    substitute(module("com.squareup.wiregrpcserver:server-generator")).using(project(":server-generator"))
   }
 }
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 include(":server")
-include(":server-generator")
 include(":samples:wire-grpc-sample:protos")
 include(":samples:wire-grpc-sample:server-plain")


### PR DESCRIPTION
- Refactored the problem so that `server-generator` doesn't depend on `server`
- which allows `server-generator` to be added on the classpath while keeping `server` as a regular compilation dependency,
- bumped kotlin and co accordingly to make the project build.